### PR TITLE
feat: allow setting of release_id for migrations

### DIFF
--- a/migrations/change_Text_optimize.js
+++ b/migrations/change_Text_optimize.js
@@ -1,0 +1,5 @@
+import optimizeTranslations from '../src/utils/optimize-translations.js';
+
+export default async function (block) {
+  await optimizeTranslations(block, 'text');
+}

--- a/migrations/change_UspTeaserItem_optimize.js
+++ b/migrations/change_UspTeaserItem_optimize.js
@@ -1,0 +1,6 @@
+
+import optimizeTranslations from '../src/utils/optimize-translations.js';
+
+export default async function (block) {
+  await optimizeTranslations(block, 'text');
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -410,6 +410,7 @@ program
   .option("--publish <PUBLISH_OPTION>", "Publish the content. It can be: all, published or published-with-changes")
   .option("--publish-languages <LANGUAGES>", "Publish specific languages")
   .option("--starts-with <STARTS_WITH>", "Filter by specific paths")
+  .option("--release-id <RELEASE_ID>", "Set release of migration output")
   .action(async (options) => {
     const field = options.field || "";
     const component = options.component || "";
@@ -417,6 +418,7 @@ program
     const publish = options.publish || null;
     const publishLanguages = options.publishLanguages || "";
     const startsWith = options.startsWith || ""
+    const releaseId = options.releaseId || 0
 
     const space = program.space;
     if (!space) {
@@ -440,7 +442,7 @@ program
       }
 
       api.setSpaceId(space);
-      await tasks.runMigration(api, component, field, { isDryrun, publish, publishLanguages, startsWith });
+      await tasks.runMigration(api, component, field, { isDryrun, publish, publishLanguages, startsWith, releaseId });
     } catch (e) {
       console.log(chalk.red("X") + " An error ocurred when run the migration file: " + e.message);
       process.exit(1);

--- a/src/tasks/migrations/run.js
+++ b/src/tasks/migrations/run.js
@@ -46,6 +46,7 @@ const runMigration = async (api, component, field, options = {}) => {
   const publish = options.publish || null
   const publishLanguages = options.publishLanguages || null
   const startsWith = options.startsWith || ""
+  const releaseId = options.releaseId || 0
 
   try {
     const fileName = getNameOfMigrationFile(component, field)
@@ -124,6 +125,10 @@ const runMigration = async (api, component, field, options = {}) => {
 
           if (!isEmpty(publishLanguages)) {
             payload.lang = publishLanguages
+          }
+
+          if (releaseId) {
+            payload.release_id = releaseId;
           }
 
           await api.put(url, payload)

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -10,3 +10,4 @@ export { default as saveFileFactory } from './save-file-factory'
 export { default as buildFilterQuery } from './build-filter-query'
 export { default as translateDeepL } from './translate-deepl';
 export { default as translateOpenAI } from './translate-openai';
+export { default as optimizeTranslations } from './optimize-translations';

--- a/src/utils/optimize-translations.js
+++ b/src/utils/optimize-translations.js
@@ -1,0 +1,30 @@
+import OpenAI from 'openai';
+
+const openai = new OpenAI({ apiKey: '' }); // TODO: add key
+
+/**
+ * @method optimizeTranslations
+ * @param {Object} block
+ * @param {string} field
+ */
+const optimizeTranslations = async (block, field) => {
+  await openai.chat.completions.create({
+    messages: [
+      {
+        role: "system",
+        content: "You are a helpful assistant designed to review text on an ecommerce website and improve sentences where the current English doesn't sound natural for an US-American and suggest one alternative wording that sounds more natural. The input is a JSON object, the fields with the key text contain the content we want to optimize. Return the complete input with these fields updated.",
+      },
+      { role: "user", content: JSON.stringify(block[field]) }
+    ],
+    model: "gpt-4-turbo",
+    response_format: { type: "json_object" },
+  })
+  .then(result => {
+    block[field] = JSON.parse(result.choices[0].message.content);
+  })
+  .catch(error => {
+      console.error(error);
+  });
+};
+
+export default optimizeTranslations;


### PR DESCRIPTION
[VOLL-496](https://myposter.atlassian.net/browse/VOLL-496)

## Features
- add `release_id` option to Storyblok CLI, which allows to set the release to write the output of the migration to
- add script to optimize translations using OpenAI